### PR TITLE
Require Ruby >= 3.2.0 and use `protocol/url/reference`.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,8 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.0'
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ end
 
 ## Requirements
 
-* [Ruby] >= 3.0.0
+* [Ruby] >= 3.2.0
 * [async-http] ~> 1.0
 
 ## Install

--- a/gemspec.yml
+++ b/gemspec.yml
@@ -18,7 +18,7 @@ metadata:
   changelog_uri:     https://github.com/ronin-rb/ronin-listener-http/blob/main/ChangeLog.md
   rubygems_mfa_required: 'true'
 
-required_ruby_version: ">= 3.0.0"
+required_ruby_version: ">= 3.2.0"
 
 dependencies:
   csv: ~> 3.0

--- a/lib/ronin/listener/http/server.rb
+++ b/lib/ronin/listener/http/server.rb
@@ -24,7 +24,7 @@ require 'async'
 require 'async/http/server'
 require 'async/http/endpoint'
 require 'async/http/protocol/response'
-require 'protocol/http/reference'
+require 'protocol/url/reference'
 
 module Ronin
   module Listener
@@ -129,7 +129,7 @@ module Ronin
         #
         def process(request)
           if (@vhost.nil? || @vhost === request.authority)
-            reference = Protocol::HTTP::Reference.parse(request.path)
+            reference = Protocol::URL::Reference.parse(request.path)
             path      = reference.path
 
             if path == @root || path.start_with?(@root)

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -480,7 +480,7 @@ describe Ronin::Listener::HTTP::Server do
           end
 
           let(:yielded_request) do
-            reference = Protocol::HTTP::Reference.parse(http_request3.path)
+            reference = Protocol::URL::Reference.parse(http_request3.path)
             path      = reference.path
             query     = reference.query
 


### PR DESCRIPTION
`Protocol::HTTP::Reference` was moved to `Protocol::URL::Reference` [here.](https://github.com/socketry/protocol-http/pull/92)